### PR TITLE
会社に所属するメンバーを追加する機能

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,86 @@
+$(function(){
+  var input_text = $("#user-search-field")
+
+  function addUser(user){
+        let html = `
+          <div class="corporation_member-user">
+            <div class="corporation_member-user__name">
+              <p class="corporation_member-user__name--text">${user.name}</p>
+            </div>
+            <div class="user-search-add corporation_member-user__btn corporation_member-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+          </div>
+        `;
+        $("#user-search-result").append(html);
+      }
+    
+      function addNoUser() {
+        let html = `
+          <div class="corporation_member-user">
+            <p class="corporation_member-user__name">ユーザーが見つかりません</p>
+          </div>
+        `;
+        $("#user-search-result").append(html);
+      }
+
+      function addDeleteUser(name, id) {
+        let html = `
+        <div class="corporation_member-user" id="${id}">
+          <div class="corporation_member-user__name">
+            <p class="corporation_member-user__name--text">${name}</p>
+          </div>
+          <div class="user-search-remove corporation_member-user__btn corporation_member-user__btn--remove js-remove-btn" data-user-id="${id}" data-user-name="${name}">削除</div>
+        </div>`;
+        $(".js-add-user").append(html);
+      }
+
+      function addMember(userId) {
+        let html = `<input value="${userId}" name="corporation[user_ids][]" type="hidden" id="corporation_user_ids_${userId}" />`;
+        $(`#${userId}`).append(html);
+      }
+
+  input_text.on("keyup",function(){
+    var input = input_text.val();
+    var path = location.pathname ;
+    $.ajax({
+      url: path,
+      type: 'GET',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users){
+      $("#user-search-result").empty();
+      if (users.length !== 0){
+        users.forEach(function(user){
+        addUser(user);
+         });
+      } else if (input.length == 0) {
+        return false;
+      }else{
+        addNoUser();
+      }
+
+    })
+    .fail(function(user){
+      alert('通信エラーです。ユーザーを表示できません。');
+    });
+  });
+
+  $(document).on("click", ".corporation_member-user__btn--add", function() {
+    const userName = $(this).attr("data-user-name");
+    const userId = $(this).attr("data-user-id");
+    $(this).parent().remove();
+    addDeleteUser(userName, userId);
+    addMember(userId);
+  });
+  $(document).on("click", ".corporation_member-user__btn--remove", function() {
+    $(this).parent().remove();
+  });
+});
+
+// {/* <p class="corporation_member-user__role">
+//             <select name="corporation[role_ids][]" class="corporation_member-user__role--item">
+//               <option value= 1 >社長 </option>
+//               <option value= 2 >社員</option>
+//               <option value= 3 selected>協力会社</option>
+//             </select>
+//           </p> */}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@ $main_font  :serif;
 @import "users";
 @import "new";
 @import "messages";
+@import "search";
 @import "font-awesome-sprockets";
 @import "font-awesome";
 

--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -52,3 +52,24 @@
 	font-size: 25px;
 }
 
+.link_tab{
+	flex-grow: 1;
+	padding:5px;
+	list-style:none;
+	width: 50%;
+	height: 30px;
+	text-align:center;
+	cursor:pointer;
+}
+
+.link_tab.is-active{
+	background: green;
+	color:#FFF;
+	// transition: all 1.2s ease-out;
+}
+
+// .box{
+// 	width: 100%;
+// 	height: 30px;
+// 	background-color: red;
+// }

--- a/app/assets/stylesheets/reset.scss
+++ b/app/assets/stylesheets/reset.scss
@@ -124,3 +124,7 @@ legend {
 }
 /* YUI CSS Detection Stamp */
 #yui3-css-stamp.cssreset { display: none; }
+
+a{
+  color: black;
+}

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -1,0 +1,99 @@
+.corporation_member-form__label{
+  font-size: 20px;
+  text-align: center;
+  display: block;
+  padding: 10px;
+}
+
+#user-search-field{
+  text-align: center;
+  margin: 0 auto;
+  display: block;
+  width: 60%;
+  height: 50px;
+  font-size: 20px;
+}
+.corporation_member-user{
+  display: flex;
+  justify-content: space-between;
+
+  &__name{
+    width: 70px;
+    height: 25px;
+    padding: 20px;
+    &--text{
+      text-align: center;
+      display: block;
+      font-size: 15px;
+
+    }
+  }
+  &__role{
+    margin: auto;
+    &--item{
+      height: 30px;
+      width: 120px;
+      font-size: 20px;
+    }
+  }
+
+  &__btn{
+    text-align: center;
+    line-height: 20px;
+    font-size: 20px;
+    padding: 10px;
+    cursor: pointer;
+    width: 60px;
+    height: 20px;
+    margin: auto 20px;
+    background-color: #9d9bff;
+    border-radius: 20px;
+    // position: absolute;
+    // right: 20px;
+    // top: 15px;
+  }
+
+}
+
+
+.corporation_member-form__action-btn{
+  background-color: rgb(250, 203, 83);
+  height: 50px;
+  width: 200px;
+  border-radius: 20px;
+  text-align: center;
+  display: block;
+  margin: 0 auto;
+}
+ 
+// .corporation_member-form__field
+// .corporation_member-form__field--left
+//   %label.corporation_member-form__label{:for => "corporation_member_メンバーを追加"} メンバーを追加する
+// .corporation_member-form__field--right
+//   .corporation_member-form__search
+//     %input#user-search-field.corporation_member-form__input{:placeholder => "追加したいメンバーの名前を入力してください", :type => "text"}/
+//   #user-search-result
+
+// -# jsで追加されたユーザー名を表示する
+// .corporation_member-form__field
+// .corporation_member-form__field--left
+//   %label.corporation_member-form__label{:for => "corporation_member_チャットメンバー"} チャットメンバー
+// .corporation_member-form__field--right
+//   #corporation_member-users.js-add-user
+//     .corporation_member-user.js-corporation_member
+//       %input{name: "@corporation[user_ids][]", type: "hidden", value: current_user.id}
+//       %p.corporation_member-user__name= current_user.name
+
+//     - @corporation.users.each do |user|
+//       - if current_user.name != user.name
+//         .corporation_member-user.js-corporation_member
+//           %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+//           %p.corporation_member-user__name
+//             = user.name
+//           %a.user-search-remove.corporation_member-user__btn.corporation_member-user__btn--remove.js-remove-btn
+//             削除
+// -# submitボタン
+// .corporation_member-form__field
+// .corporation_member-form__field--left
+// .corporation_member-form__field--right
+//   = f.submit class: 'corporation_member-form__action-btn'

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -8,7 +8,7 @@
   text-align: center;
   font-family: serif;
   line-height: 50px;
-  margin: 20px auto 0;
+  // margin: 20px auto 0;
   text-align: center;
   line-height: 50px;
 

--- a/app/controllers/corporations_controller.rb
+++ b/app/controllers/corporations_controller.rb
@@ -5,6 +5,12 @@ class CorporationsController < ApplicationController
 
   def new
     @corporation = Corporation.new
+    return nil if params[:keyword] == ""
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 
   def create
@@ -12,8 +18,29 @@ class CorporationsController < ApplicationController
     redirect_to root_path
   end
 
+  def edit
+    @corporation = Corporation.find(params[:id])    
+    return nil if params[:keyword] == ""
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+
+  end
+
+  def update
+    @corporation = Corporation.find(params[:id])
+    @corporation.update(corporation_params)
+    redirect_to corporation_projects_path(@corporation.id)
+  end
+
   private
   def corporation_params
-    params.require(:corporation).permit(:name)
+    params.require(:corporation).permit(:name, user_ids: [])
   end
 end
+
+
+
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,20 @@
 class UsersController < ApplicationController
+  def index
+    @corporation = Corporation.find(params[:corporation_id])
+    @user = User.new
+    return nil if params[:keyword] == ""
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+  def create
+    @user = User.new(role_params)
+    @user.save
+  end
+
+
   def edit
   end
 
@@ -15,6 +31,8 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name, :email)
   end
-
+  def role_params
+    params.require(:user).permit(corporation_ids: [], role_ids: [])
+  end
 
 end

--- a/app/models/corporation.rb
+++ b/app/models/corporation.rb
@@ -1,4 +1,6 @@
 class Corporation < ApplicationRecord
-  has_many :users, through: :corporation_users
+  has_many :users, through: :corporation_user_roles
+  # has_many :roles, through: :corporation_user_roles
+  has_many :corporation_user_roles
   has_many :projects
 end

--- a/app/models/corporation_user_role.rb
+++ b/app/models/corporation_user_role.rb
@@ -1,5 +1,5 @@
 class CorporationUserRole < ApplicationRecord
   belongs_to :user
   belongs_to :corporation
-  belongs_to :role
+  # belongs_to :role
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,2 +1,6 @@
 class Role < ApplicationRecord
+  # has_many :users, through: :corporation_user_roles
+  # has_many :corporations, through: :corporation_user_roles
+  # has_many :corporation_user_roles
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :name, presence: true
-
+  has_many :corporations, through: :corporation_user_roles
+  # has_many :roles, through: :corporation_user_roles
+  has_many :corporation_user_roles
 end

--- a/app/views/corporations/edit.html.haml
+++ b/app/views/corporations/edit.html.haml
@@ -1,0 +1,62 @@
+.header
+  .header__text
+    WORKER
+  = link_to corporations_path do
+    <i class="fas fa-arrow-left"></i>
+  = link_to edit_user_path(current_user) do
+    <i class="fas fa-cog"></i>
+  = link_to destroy_user_session_path, method: :delete do
+    <i class="fas fa-sign-out-alt"></i>
+.main
+  .index_header
+    %ul 
+      %li.list_index
+        = @corporation.name
+      %li.list_new
+        = link_to new_corporation_project_path(@corporation.id) do
+          新規登録
+  %ul.tab-group
+    %li.link_tab
+      = link_to corporation_projects_path(@corporation.id) do
+        案件一覧
+    %li.link_tab.is-active メンバー追加
+  .panel-group
+    .panel
+    .panel.is-show 
+      = form_for @corporation do |f|
+        -# メンバーを検索するボックス
+        .corporation_member-form__field
+          .corporation_member-form__field--left
+            %label.corporation_member-form__label メンバーを追加する
+          .corporation_member-form__field--right
+            .corporation_member-form__search
+              %input#user-search-field.corporation_member-form__input{:placeholder => "名前を入力してください", :type => "text"}/
+            #user-search-result
+
+        -# jsで追加されたユーザー名を表示する
+        .corporation_member-form__field
+          .corporation_member-form__field--left
+            %label.corporation_member-form__label 現在のチャットメンバー
+          .corporation_member-form__field--right
+            #corporation_member-users.js-add-user
+
+              .corporation_member-user.js-corporation_member
+                %input{name: "corporation[user_ids][]", type: "hidden", value: current_user.id}
+                -# %input{name: "corporation[role_ids][]", type: "hidden", value: 1}
+                .corporation_member-user__name
+                  %p.corporation_member-user__name--text= current_user.name
+
+              - @corporation.users.each do |user|
+                - if current_user.name != user.name
+                  .corporation_member-user.js-corporation_member
+                    %input{name: "corporation[user_ids][]", type: "hidden", value: user.id}
+                    .corporation_member-user__name
+                      %p.corporation_member-user__name--text
+                        = user.name
+                    %a.user-search-remove.corporation_member-user__btn.corporation_member-user__btn--remove.js-remove-btn
+                      削除
+        -# submitボタン
+        .corporation_member-form__field
+          .corporation_member-form__field--left
+          .corporation_member-form__field--right
+            = f.submit "メンバーを追加する", class: 'corporation_member-form__action-btn'

--- a/app/views/corporations/edit.json.jbuilder
+++ b/app/views/corporations/edit.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/app/views/corporations/new.html.haml
+++ b/app/views/corporations/new.html.haml
@@ -1,6 +1,8 @@
 .header
   .header__text
     WORKER
+    = link_to root_path do
+      <i class="fas fa-arrow-left"></i>
 .main
   = form_for @corporation do |f|
     .corporation-form
@@ -8,31 +10,38 @@
         = f.label :会社名, class: 'chat-group-form__label'
       .corporation-form__name-area
         = f.text_field :name, class: 'corporation-form__name-area__box'
-    -# .chat-group-form__field
-    -#   .chat-group-form__field--left
-    -#     %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} 追加したい人を検索
-    -#   .chat-group-form__field--right
-    -#     .chat-group-form__search.clearfix
-    -#       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
-    -#     #user-search-result
 
-    -# .chat-group-form__field.clearfix
-    -#   .chat-group-form__field--left
-    -#     %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} メンバーを登録
-    -#   .chat-group-form__field--right
-    -#     #chat-group-users.js-add-user
-    -#       .chat-group-user.clearfix.js-chat-member
-    -#         %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
-    -#         %p.chat-group-user__name= current_user.name
+    .corporation_member-form__field
+      .corporation_member-form__field--left
+        %label.corporation_member-form__label メンバーを追加する
+      .corporation_member-form__field--right
+        .corporation_member-form__search
+          %input#user-search-field.corporation_member-form__input{:placeholder => "名前を入力してください", :type => "text"}/
+        #user-search-result
 
-          -# - group.users.each do |user|
-          -#   - if current_user.name != user.name
-          -#     .chat-group-user.clearfix.js-chat-member
-          -#       %input{name: "group[user_ids][]", type: "hidden", value: user.id}
-          -#       %p.chat-group-user__name
-          -#         = user.name
-          -#       %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
-          -#         削除
+    -# jsで追加されたユーザー名を表示する
+    .corporation_member-form__field
+      .corporation_member-form__field--left
+        %label.corporation_member-form__label 現在のチャットメンバー
+      .corporation_member-form__field--right
+        #corporation_member-users.js-add-user
+
+          .corporation_member-user.js-corporation_member
+            %input{name: "corporation[user_ids][]", type: "hidden", value: current_user.id}
+            %input{name: "corporation[role_ids][]", type: "hidden", value: 1}
+            .corporation_member-user__name
+              %p.corporation_member-user__name--text= current_user.name
+
+          - @corporation.users.each do |user|
+            - if current_user.name != user.name
+              .corporation_member-user.js-corporation_member
+                %input{name: "corporation[user_ids][]", type: "hidden", value: user.id}
+                -# %input{name: "corporation[role_ids][]", type: "hidden", value: 2}
+                .corporation_member-user__name
+                  %p.corporation_member-user__name--text
+                    = user.name
+                %a.user-search-remove.corporation_member-user__btn.corporation_member-user__btn--remove.js-remove-btn
+                  削除
     .corporation-form__submit
       = f.submit value: "会社を登録する", class: "corporation-form__submit__btn"
 

--- a/app/views/corporations/new.json.jbuilder
+++ b/app/views/corporations/new.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,32 +1,36 @@
-.account-page
-  .account-page__header
-    %h5 新規アカウントの作成
-  .user-form
-    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-      = devise_error_messages!
-      .field
-        .field-label
-          = f.label :名前
-        .field-input
-          = f.text_field :name, autofocus: true, class: 'field-input__text'
-      .field
-        .field-label
-          = f.label :メールアドレス
-        .field-input
-          = f.email_field :email, class: 'field-input__text'
-      .field
-        .field-label
-          = f.label :パスワード
-        .field-input
-          = f.password_field :password, autocomplete: "off", class: 'field-input__text'
-      .field
-        .field-label
-          = f.label :確認用パスワード
-        .field-input
-          = f.password_field :password_confirmation, autocomplete: "off", class: 'field-input__text'
-      .actions.field
-        = f.submit "アカウントを作成", class: 'signin_btn'
-  .account-page__bottom
-    = link_to new_user_session_path class:"account-page__bottom__link" do
-      .account-page__bottom__link--text
-        ログイン画面へ
+.header
+  .header__text
+    WORKER
+.main
+  .account-page
+    .account-page__header
+      %h5 新規アカウントの作成
+    .user-form
+      = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+        = devise_error_messages!
+        .field
+          .field-label
+            = f.label :名前
+          .field-input
+            = f.text_field :name, autofocus: true, class: 'field-input__text'
+        .field
+          .field-label
+            = f.label :メールアドレス
+          .field-input
+            = f.email_field :email, class: 'field-input__text'
+        .field
+          .field-label
+            = f.label :パスワード
+          .field-input
+            = f.password_field :password, autocomplete: "off", class: 'field-input__text'
+        .field
+          .field-label
+            = f.label :確認用パスワード
+          .field-input
+            = f.password_field :password_confirmation, autocomplete: "off", class: 'field-input__text'
+        .actions.field
+          = f.submit "アカウントを作成", class: 'signin_btn'
+    .account-page__bottom
+      = link_to new_user_session_path class:"account-page__bottom__link" do
+        .account-page__bottom__link--text
+          ログイン画面へ

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,21 +1,25 @@
-.account-page
-  .account-page__header
-    Log in
-  .user-form
-    = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-      .field
-        .field-label
-          = f.label :メールアドレス
-        .field-input
-          = f.email_field :email, autofocus: true, class: 'field-input__text'
+.header
+  .header__text
+    WORKER
+.main
+  .account-page
+    .account-page__header
+      Log in
+    .user-form
+      = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
         .field
           .field-label
-            = f.label :パスワード
+            = f.label :メールアドレス
           .field-input
-            = f.password_field :password, autocomplete: "off",class: 'field-input__text'
-        .actions
-          = f.submit "ログイン", class: 'login_btn'
-  .account-page__bottom
-    = link_to new_user_registration_path class:"account-page__bottom__link" do
-      .account-page__bottom__link--text
-        アカウント新規登録
+            = f.email_field :email, autofocus: true, class: 'field-input__text'
+          .field
+            .field-label
+              = f.label :パスワード
+            .field-input
+              = f.password_field :password, autocomplete: "off",class: 'field-input__text'
+          .actions
+            = f.submit "ログイン", class: 'login_btn'
+    .account-page__bottom
+      = link_to new_user_registration_path class:"account-page__bottom__link" do
+        .account-page__bottom__link--text
+          アカウント新規登録

--- a/app/views/project_messages/index.html.haml
+++ b/app/views/project_messages/index.html.haml
@@ -13,9 +13,11 @@
       %li.list_index
         = @project.name
   %ul.tab-group
-    = link_to corporation_project_path(@corporation.id, @project.id), class:"tab" do
-      詳細
-    %li.tab.is-active メッセージ
+    %li.link_tab
+      = link_to corporation_project_path(@corporation.id, @project.id), class:"tab" do
+        詳細
+    %li.link_tab.is-active
+      メッセージ
 
   .project_messages
     = render @messages

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -16,52 +16,10 @@
         = link_to new_corporation_project_path(@corporation.id) do
           新規登録
   %ul.tab-group
-    %li.tab.is-active 案件一覧
-    %li.tab メンバー追加
+    %li.link_tab.is-active 案件一覧
+    %li.link_tab
+      = link_to edit_corporation_path(@corporation.id) do
+        メンバー追加
   .panel-group
     .panel.is-show 
       = render @projects
-    .panel
-      インクリメンタルサーチを実装
-      -# = form_for group do |f|
-      -#   - if group.errors.any?
-      -#     .chat-group-form__errors
-      -#       %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
-      -#       %ul
-      -#         - group.errors.full_messages.each do |message|
-      -#           %li= message
-      -#   .chat-group-form__field
-      -#     .chat-group-form__field--left
-      -#       = f.label :name, class: 'chat-group-form__label'
-      -#     .chat-group-form__field--right
-      -#       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-      -#   .chat-group-form__field
-      -#     .chat-group-form__field--left
-      -#       %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
-      -#     .chat-group-form__field--right
-      -#       .chat-group-form__search.clearfix
-      -#         %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
-      -#       #user-search-result
-
-      -#   .chat-group-form__field.clearfix
-      -#     .chat-group-form__field--left
-      -#       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
-      -#     .chat-group-form__field--right
-      -#       #chat-group-users.js-add-user
-      -#         .chat-group-user.clearfix.js-chat-member
-      -#           %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
-      -#           %p.chat-group-user__name= current_user.nickname
-
-      -#         - group.users.each do |user|
-      -#           - if current_user.nickname != user.nickname
-      -#             .chat-group-user.clearfix.js-chat-member
-      -#               %input{name: "group[user_ids][]", type: "hidden", value: user.id}
-      -#               %p.chat-group-user__name
-      -#                 = user.nickname
-      -#               %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
-      -#                 削除
-
-      -#   .chat-group-form__field.clearfix
-      -#     .chat-group-form__field--left
-      -#     .chat-group-form__field--right
-      -#       = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -1,11 +1,17 @@
 .header
   .header__text
     WORKER
+    = link_to  corporation_projects_path(@corporation.id) do
+      <i class="fas fa-arrow-left"></i>
 .main
+  .index_header
+    %ul 
+      %li.list_index
+        = @corporation.name
   = form_for [@corporation, @project] do |f|
     %ul.tab-group
-      %li.tab.is-active 案件一覧
-      %li.tab メッセージ
+      %li.tab.is-active 情報
+      %li.tab 内容
     .panel-group
       .panel.is-show 
         .new__project
@@ -37,6 +43,6 @@
           .new__project__content
             = f.label :"内容", class: 'new__project__content--text'
           .new__project__content__form
-            = f.text_area :text, class: 'new__project__content__form--area'
+            = f.text_area :text, class: 'new__project__content__form--area', placeholder:"仕事内容等を入力してください"
           .new__project__submit
             = f.submit "案件を登録する", class: 'new__project__submit__btn'

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -13,9 +13,10 @@
       %li.list_index
         = @project.name
   %ul.tab-group
-    %li.tab.is-active 詳細
-    = link_to corporation_project_project_messages_path(@corporation.id, @project.id), class:"tab" do
-      メッセージ
+    %li.link_tab.is-active 詳細
+    %li.link_tab
+      = link_to corporation_project_project_messages_path(@corporation.id, @project.id), class:"tab" do
+        メッセージ
   .panel-group
     .panel.is-show 
       .project__member.project__label  人数

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,0 +1,73 @@
+.header
+  .header__text
+    WORKER
+  = link_to corporations_path do
+    <i class="fas fa-arrow-left"></i>
+  = link_to edit_user_path(current_user) do
+    <i class="fas fa-cog"></i>
+  = link_to destroy_user_session_path, method: :delete do
+    <i class="fas fa-sign-out-alt"></i>
+.main
+  .index_header
+    %ul 
+      %li.list_index
+        = @corporation.name
+      %li.list_new
+        = link_to new_corporation_project_path(@corporation.id) do
+          新規登録
+  %ul.tab-group
+    %li.link_tab
+      = link_to corporation_projects_path(@corporation.id) do
+        案件一覧
+    %li.link_tab.is-active メンバー追加
+  .panel-group
+    .panel
+    .panel.is-show 
+      = form_for @user do |f|
+        -# エラー文を表示する
+        -# - if group.errors.any?
+        -#   .chat-group-form__errors
+        -#     %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+        -#     %ul
+        -#       - group.errors.full_messages.each do |message|
+        -#         %li= message
+        -# グループの名称を決定する
+        -# .chat-group-form__field
+        -#   .chat-group-form__field--left
+        -#     = f.label :name, class: 'chat-group-form__label'
+        -#   .chat-group-form__field--right
+        -#     = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+        -# メンバーを検索するボックス
+        .corporation_member-form__field
+          .corporation_member-form__field--left
+            %label.corporation_member-form__label メンバーを追加する
+          .corporation_member-form__field--right
+            .corporation_member-form__search
+              %input#user-search-field.corporation_member-form__input{:placeholder => "名前を入力してください", :type => "text"}/
+            #user-search-result
+
+        -# jsで追加されたユーザー名を表示する
+        .corporation_member-form__field
+          .corporation_member-form__field--left
+            %label.corporation_member-form__label 現在のチャットメンバー
+          .corporation_member-form__field--right
+            #corporation_member-users.js-add-user
+              .corporation_member-user.js-corporation_member
+                %input{name: "@corporation[user_ids][]", type: "hidden", value: current_user.id}
+                .corporation_member-user__name
+                  %p.corporation_member-user__name--text= current_user.name
+
+              - @corporation.users.each do |user|
+                - if current_user.name != user.name
+                  .corporation_member-user.js-corporation_member
+                    %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+                    .corporation_member-user__name
+                      %p.corporation_member-user__name--text
+                        = user.name
+                    %a.user-search-remove.corporation_member-user__btn.corporation_member-user__btn--remove.js-remove-btn
+                      削除
+        -# submitボタン
+        .corporation_member-form__field
+          .corporation_member-form__field--left
+          .corporation_member-form__field--right
+            = f.submit "メンバーを追加する", class: 'corporation_member-form__action-btn'

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get 'corporations/index'
   root "corporations#index"
   resources :users
+  resources :addcorporation_members
   resources :corporations do
     resources :projects do
       resources :project_messages

--- a/db/migrate/20200225111609_create_corporation_user_roles.rb
+++ b/db/migrate/20200225111609_create_corporation_user_roles.rb
@@ -3,7 +3,7 @@ class CreateCorporationUserRoles < ActiveRecord::Migration[5.0]
     create_table :corporation_user_roles do |t|
       t.references  :user,        foreign_key: true
       t.references  :corporation, foreign_key: true
-      t.references  :role,        foreign_key: true
+      # t.references  :role,        foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,11 +15,9 @@ ActiveRecord::Schema.define(version: 20200225112441) do
   create_table "corporation_user_roles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
     t.integer  "corporation_id"
-    t.integer  "role_id"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.index ["corporation_id"], name: "index_corporation_user_roles_on_corporation_id", using: :btree
-    t.index ["role_id"], name: "index_corporation_user_roles_on_role_id", using: :btree
     t.index ["user_id"], name: "index_corporation_user_roles_on_user_id", using: :btree
   end
 
@@ -83,7 +81,6 @@ ActiveRecord::Schema.define(version: 20200225112441) do
   end
 
   add_foreign_key "corporation_user_roles", "corporations"
-  add_foreign_key "corporation_user_roles", "roles"
   add_foreign_key "corporation_user_roles", "users"
   add_foreign_key "project_messages", "projects"
   add_foreign_key "project_messages", "users"


### PR DESCRIPTION
# What
会社を立ち上げ、そこにカレントユーザーとその他全ユーザーの中から検索して指定したユーザーを追加し会社の構成員として登録する機能を実装しました。
引き続きそのメンバー以外には会社名が表示されないようにビューを変更していきます。