### PR TITLE
会社構成員のみ会社名が表示される仕様

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,6 +5,7 @@ class ProjectsController < ApplicationController
     @project = Project.new
     @corporation = Corporation.find(params[:corporation_id])
     @projects = @corporation.projects.all
+    @id = (params[:corporation_id])
   end
 
   def new
@@ -13,13 +14,7 @@ class ProjectsController < ApplicationController
   end
 
   def create
-    # @corporation = Corporation.find(params[:corporation_id])
     Project.create(project_params)
-    # binding.pry
-    # redirect_to corporation_projects_path(params[:corporation_id])
-    # @corporation = Corporation.find(params[:corporation_id])
-    # @project = @corporation.projects.new(project_params)
-    # @project.save
     redirect_to corporation_projects_path(params[:corporation_id])
 
   end
@@ -30,10 +25,21 @@ class ProjectsController < ApplicationController
     @corporation = Corporation.find(params[:corporation_id])
   end
 
+  # def edit
 
+  # end
+
+  # def update
+
+  # end
 
   private
   def project_params
     params.require(:project).permit(:name, :member, :time, :address, :text).merge(corporation_id: params[:corporation_id])
+  end
+
+  private
+  def corporation_params
+    params.require(:corporation).permit(:name, user_ids: [])
   end
 end

--- a/app/views/corporations/_corporation.html.haml
+++ b/app/views/corporations/_corporation.html.haml
@@ -1,5 +1,0 @@
-.index
-  .index__btn
-    = link_to corporation_projects_path(corporation.id) do
-      .index__btn--text
-        = corporation.name

--- a/app/views/corporations/index.html.haml
+++ b/app/views/corporations/index.html.haml
@@ -12,7 +12,12 @@
         会社一覧
       %li.list_new
         -# = link_to new_company_path
-        %a(href="/corporations/new")
+        = link_to new_corporation_path do
           登録
-  = render @corporation
-  
+
+  - current_user.corporations.each do |corporation|
+    .index
+      .index__btn
+        = link_to corporation_projects_path(corporation.id) do
+          .index__btn--text
+            = corporation.name

--- a/app/views/projects/_project.html.haml
+++ b/app/views/projects/_project.html.haml
@@ -1,3 +1,4 @@
+-# - if current_user.id != project.users.ids
 .index
   .index__btn
     = link_to corporation_project_path(@corporation.id, project.id) do

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,3 +1,4 @@
+-# - if current_user.corporations.ids == @id
 .header
   .header__text
     WORKER
@@ -23,3 +24,8 @@
   .panel-group
     .panel.is-show 
       = render @projects
+
+
+
+
+


### PR DESCRIPTION
# What
カレントユーザーが所属する会社名だけが会社一覧に表示される仕様に変更しました。
今の仕様だとurlの直接入力で所属しない会社の詳細ページを表示することができてしまうので後日変更予定です。